### PR TITLE
Add version text

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,9 @@ jobs:
             git push origin ${{ github.event.inputs.tag }}
           fi
 
+      - name: Write version.txt into commec-dbs
+        run: echo "${{ github.event.inputs.tag }}" > commec-dbs/commec-db-version.txt
+
       - name: Create ZIP of commec-dbs
         run: |
           cd commec-dbs


### PR DESCRIPTION
To easily communicate to commec, a commec-db-version.txt file is automatically generated and put in the zip file. This can be used during commec screen, and commec setup, to check if the current version is also the most recent version available on github.